### PR TITLE
WL-3447 Leaving joinable site does not result in frame within the frame.

### DIFF
--- a/tool/src/java/org/sakaiproject/cheftool/VelocityPortletPaneledAction.java
+++ b/tool/src/java/org/sakaiproject/cheftool/VelocityPortletPaneledAction.java
@@ -631,7 +631,10 @@ public abstract class VelocityPortletPaneledAction extends ToolServlet
 
 			try
 			{
-				res.sendRedirect(redirect);
+				//to prevent the 'response already committed' error
+				if(!(res.isCommitted())){
+					res.sendRedirect(redirect);
+				}
 			}
 			catch (IOException e)
 			{


### PR DESCRIPTION
Checking response before redirect if it's committed or not.
